### PR TITLE
Make Heap Send for spin 0.4.1+

### DIFF
--- a/crates/alloc_buddy_simple/Cargo.toml
+++ b/crates/alloc_buddy_simple/Cargo.toml
@@ -18,4 +18,4 @@ license = "Apache-2.0/MIT"
 use-as-rust-allocator = ["spin"]
 
 [dependencies]
-spin = { version = "^0.3.4", optional = true }
+spin = { version = ">=0.3.4,<0.5", optional = true }

--- a/crates/alloc_buddy_simple/src/heap.rs
+++ b/crates/alloc_buddy_simple/src/heap.rs
@@ -63,6 +63,9 @@ pub struct Heap<'a> {
     min_block_size_log2: u8,
 }
 
+// A Heap struct is the sole owner of the memory it manages
+unsafe impl<'a> Send for Heap<'a> {}
+
 impl<'a> Heap<'a> {
     /// Create a new heap.  `heap_base` must be aligned on a
     /// `MIN_HEAP_ALIGN` boundary, `heap_size` must be a power of 2, and


### PR DESCRIPTION
I don't see any reason for it not to be `Send`. This is [necessary to be able to share it with a Mutex](https://github.com/mvdnes/spin-rs/issues/27).